### PR TITLE
Verify that the mapping actually maps all the properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
 

--- a/src/main/java/me/sokolenko/test/compareConverters/Converter.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/Converter.java
@@ -9,4 +9,5 @@ public interface Converter {
 
     me.sokolenko.test.compareConverters.model.target.Category map(Category source);
 
+    Category unmap(me.sokolenko.test.compareConverters.model.target.Category source);
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/Main.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/Main.java
@@ -43,6 +43,13 @@ public class Main {
 
             long end = System.nanoTime();
 
+            Category rev = converter.unmap(result);
+
+            if (!rev.equals(category)) {
+                System.err.println("ERROR - results don't match");
+                System.exit(1);
+            }
+
             latencies[i] = (int) (end - start);
         }
 

--- a/src/main/java/me/sokolenko/test/compareConverters/dozer/DozerConverter.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/dozer/DozerConverter.java
@@ -23,4 +23,9 @@ public class DozerConverter implements Converter {
     public me.sokolenko.test.compareConverters.model.target.Category map(Category source) {
         return mapper.map(source, me.sokolenko.test.compareConverters.model.target.Category.class);
     }
+
+    @Override
+    public Category unmap(me.sokolenko.test.compareConverters.model.target.Category source) {
+        return mapper.map(source, Category.class);
+    }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/manual/ManualConverter.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/manual/ManualConverter.java
@@ -62,14 +62,61 @@ public class ManualConverter implements Converter {
         return target;
     }
 
+    @Override
+    public me.sokolenko.test.compareConverters.model.source.Category unmap(Category target) {
+        me.sokolenko.test.compareConverters.model.source.Category source = new me.sokolenko.test.compareConverters.model.source.Category();
+        source.setId(target.getId());
+        source.setName(target.getCategoryName());
+        source.setProducts(toSource(target.getProducts()));
+        source.setShipping(toSource(target.getShipping()));
+        source.setUrl(target.getUrl());
+        source.setVisible(target.isVisible());
+        source.setType(target.getType());
+        source.setHasChildren(target.isHasChildren());
+        source.setRelatedIds(target.getRelatedIds());
+        source.setFrom(new Date(target.getFrom().getTime()));
+        source.setClearanceStartDays(target.getClearanceStartDays());
+        source.setPosition(target.getPosition());
+        source.setCountryEligible(target.getCountryEligible());
+        source.setNew(target.isNew());
+        source.setActive(target.getActive());
+        source.setParameters(toSourceParameters(target.getParameters()));
+        source.setPrimaryImageSource(target.getPrimaryImageSource());
+        source.setPrimaryPortraitSource(target.getPrimaryPortraitSource());
+        source.setAvailableTo(target.getAvailableTo());
+        source.setAuthor(target.getAuthor());
+        source.setCreatedAt(new Date(target.getCreatedAt().getTime()));
+        source.setUpdatedAt(new Date(target.getUpdatedAt().getTime()));
+        source.setParentCategory(toSource(target.getParentCategory()));
+        source.setDomainValues(target.getDomainValues());
+        source.setPrimaryImage(toSource(target.getPrimaryImage()));
+        source.setSecondaryImages(toSourceImages(target.getSecondaryImages()));
+        source.setBrand(toSource(target.getBrand()));
+        source.setPopularity(target.getPopularity());
+        source.setCopies(target.getCopies());
+        source.setResources(toSourceAssets(target.getResources()));
+
+        return source;
+    }
+
     private List<Resource> toTargetAssets(List<me.sokolenko.test.compareConverters.model.source.Resource> source) {
-        List<Resource> target = new ArrayList<Resource>();
+        List<Resource> target = new ArrayList<>();
 
         for (me.sokolenko.test.compareConverters.model.source.Resource sourceAsset : source) {
             target.add(toTarget(sourceAsset));
         }
 
         return target;
+    }
+
+    private List<me.sokolenko.test.compareConverters.model.source.Resource> toSourceAssets(List<Resource> target) {
+        List<me.sokolenko.test.compareConverters.model.source.Resource> source = new ArrayList<>();
+
+        for (Resource sourceAsset : target) {
+            source.add(toSource(sourceAsset));
+        }
+
+        return source;
     }
 
     private Resource toTarget(me.sokolenko.test.compareConverters.model.source.Resource source) {
@@ -87,14 +134,39 @@ public class ManualConverter implements Converter {
         return target;
     }
 
+    private me.sokolenko.test.compareConverters.model.source.Resource toSource(Resource target) {
+        me.sokolenko.test.compareConverters.model.source.Resource source = new me.sokolenko.test.compareConverters.model.source.Resource();
+        source.setId(target.getId());
+        source.setDescription(target.getDescription());
+        source.setFileName(target.getFileName());
+        source.setLinks(toSourceLinks(target.getLinks()));
+        source.setHeight((int) target.getHeight());
+        source.setWidth((int) target.getWidth());
+        source.setText(target.getText());
+        source.setType(toSource(target.getType()));
+        source.setParameters(toSourceParameters(target.getParameters()));
+
+        return source;
+    }
+
     private List<Link> toTargetLinks(List<me.sokolenko.test.compareConverters.model.source.Link> source) {
-        List<Link> target = new ArrayList<Link>();
+        List<Link> target = new ArrayList<>();
 
         for (me.sokolenko.test.compareConverters.model.source.Link sourceLink : source) {
             target.add(toTarget(sourceLink));
         }
 
         return target;
+    }
+
+    private List<me.sokolenko.test.compareConverters.model.source.Link> toSourceLinks(List<Link> target) {
+        List<me.sokolenko.test.compareConverters.model.source.Link> source = new ArrayList<>();
+
+        for (Link targetLink : target) {
+            source.add(toSource(targetLink));
+        }
+
+        return source;
     }
 
     private Link toTarget(me.sokolenko.test.compareConverters.model.source.Link source) {
@@ -108,12 +180,31 @@ public class ManualConverter implements Converter {
         return target;
     }
 
+    private me.sokolenko.test.compareConverters.model.source.Link toSource(Link target) {
+        me.sokolenko.test.compareConverters.model.source.Link source = new me.sokolenko.test.compareConverters.model.source.Link();
+        source.setText(target.getText());
+        source.setPosition(target.getPosition());
+        source.setParameters(toSourceParameters(target.getParameters()));
+        source.setLinkType(toSource(target.getLinkType()));
+        source.setValue(target.getValue());
+
+        return source;
+    }
+
     private LinkType toTarget(me.sokolenko.test.compareConverters.model.source.LinkType source) {
         return LinkType.valueOf(source.name());
     }
 
+    private me.sokolenko.test.compareConverters.model.source.LinkType toSource(LinkType target) {
+        return me.sokolenko.test.compareConverters.model.source.LinkType.valueOf(target.name());
+    }
+
     private ResourceType toTarget(me.sokolenko.test.compareConverters.model.source.ResourceType source) {
         return ResourceType.valueOf(source.name());
+    }
+
+    private me.sokolenko.test.compareConverters.model.source.ResourceType toSource(ResourceType target) {
+        return me.sokolenko.test.compareConverters.model.source.ResourceType.valueOf(target.name());
     }
 
     private Brand toTarget(me.sokolenko.test.compareConverters.model.source.Brand source) {
@@ -124,14 +215,32 @@ public class ManualConverter implements Converter {
         return target;
     }
 
+    private me.sokolenko.test.compareConverters.model.source.Brand toSource(Brand target) {
+        me.sokolenko.test.compareConverters.model.source.Brand source = new me.sokolenko.test.compareConverters.model.source.Brand();
+        source.setBrandName(target.getBrandName());
+        source.setRightOwner(target.getRightOwner());
+
+        return source;
+    }
+
     private List<Image> toTargetImages(List<me.sokolenko.test.compareConverters.model.source.Image> source) {
-        List<Image> target = new ArrayList<Image>();
+        List<Image> target = new ArrayList<>();
 
         for (me.sokolenko.test.compareConverters.model.source.Image sourceImage : source) {
             target.add(toTarget(sourceImage));
         }
 
         return target;
+    }
+
+    private List<me.sokolenko.test.compareConverters.model.source.Image> toSourceImages(List<Image> target) {
+        List<me.sokolenko.test.compareConverters.model.source.Image> source = new ArrayList<>();
+
+        for (Image targetImage : target) {
+            source.add(toSource(targetImage));
+        }
+
+        return source;
     }
 
     private Image toTarget(me.sokolenko.test.compareConverters.model.source.Image source) {
@@ -142,6 +251,14 @@ public class ManualConverter implements Converter {
         return target;
     }
 
+    private me.sokolenko.test.compareConverters.model.source.Image toSource(Image target) {
+        me.sokolenko.test.compareConverters.model.source.Image source = new me.sokolenko.test.compareConverters.model.source.Image();
+        source.setName(target.getName());
+        source.setSeq(target.getSeq());
+
+        return source;
+    }
+
     private ParentCategory toTarget(me.sokolenko.test.compareConverters.model.source.ParentCategory source) {
         ParentCategory target = new ParentCategory();
         target.setId(source.getId());
@@ -150,14 +267,32 @@ public class ManualConverter implements Converter {
         return target;
     }
 
+    private me.sokolenko.test.compareConverters.model.source.ParentCategory toSource(ParentCategory target) {
+        me.sokolenko.test.compareConverters.model.source.ParentCategory source = new me.sokolenko.test.compareConverters.model.source.ParentCategory();
+        source.setId(target.getId());
+        source.setName(target.getName());
+
+        return source;
+    }
+
     private List<Parameter> toTargetParameters(List<me.sokolenko.test.compareConverters.model.source.Parameter> source) {
-        List<Parameter> target = new ArrayList<Parameter>(source.size());
+        List<Parameter> target = new ArrayList<>(source.size());
 
         for (me.sokolenko.test.compareConverters.model.source.Parameter sourceParameter : source) {
             target.add(toTarget(sourceParameter));
         }
 
         return target;
+    }
+
+    private List<me.sokolenko.test.compareConverters.model.source.Parameter> toSourceParameters(List<Parameter> target) {
+        List<me.sokolenko.test.compareConverters.model.source.Parameter> source = new ArrayList<>(target.size());
+
+        for (Parameter targetParameter : target) {
+            source.add(toSource(targetParameter));
+        }
+
+        return source;
     }
 
     private ShippingRule toTarget(me.sokolenko.test.compareConverters.model.source.ShippingRule source) {
@@ -170,8 +305,18 @@ public class ManualConverter implements Converter {
         return target;
     }
 
+    private me.sokolenko.test.compareConverters.model.source.ShippingRule toSource(ShippingRule target) {
+        me.sokolenko.test.compareConverters.model.source.ShippingRule source = new me.sokolenko.test.compareConverters.model.source.ShippingRule();
+        source.setReturnConstraints(target.getReturnConstraints());
+        source.setNotes(target.getNotes());
+        source.setGiftable(target.getGiftable());
+        source.setShipDays(target.getShipDays());
+
+        return source;
+    }
+
     private ArrayList<Product> toTarget(List<me.sokolenko.test.compareConverters.model.source.Product> source) {
-        ArrayList<Product> products = new ArrayList<Product>();
+        ArrayList<Product> products = new ArrayList<>();
         for (me.sokolenko.test.compareConverters.model.source.Product sourceProduct : source) {
             Product targetProduct = new Product();
             targetProduct.setId(sourceProduct.getId());
@@ -195,8 +340,33 @@ public class ManualConverter implements Converter {
         return products;
     }
 
+    private ArrayList<me.sokolenko.test.compareConverters.model.source.Product> toSource(List<Product> target) {
+        ArrayList<me.sokolenko.test.compareConverters.model.source.Product> products = new ArrayList<>();
+        for (Product targetProduct : target) {
+            me.sokolenko.test.compareConverters.model.source.Product sourceProduct = new me.sokolenko.test.compareConverters.model.source.Product();
+            sourceProduct.setId(targetProduct.getId());
+            sourceProduct.setPrice(toSource(targetProduct.getPrice()));
+            sourceProduct.setAvailability(toSource(targetProduct.getAvailability()));
+            sourceProduct.setIndicator(targetProduct.getIndicator());
+            sourceProduct.setEnabled(targetProduct.isEnabled());
+            sourceProduct.setAddByApp(targetProduct.getAddByApp());
+            sourceProduct.setDescription(targetProduct.getDescription());
+            sourceProduct.setCode(targetProduct.getCode());
+            sourceProduct.setExpired(targetProduct.getExpired());
+            sourceProduct.setSurchargeFee(targetProduct.getSurchargeFee());
+            sourceProduct.setHistory(targetProduct.isHistory());
+            sourceProduct.setOrderable(targetProduct.isOrderable());
+            sourceProduct.setBackorderable(targetProduct.isBackorderable());
+            sourceProduct.setAttributes(toSource(targetProduct.getParameters()));
+            sourceProduct.setActive(targetProduct.getActive());
+
+            products.add(sourceProduct);
+        }
+        return products;
+    }
+
     private Map<String, Parameter> toTarget(Map<String, me.sokolenko.test.compareConverters.model.source.Parameter> source) {
-        Map<String, Parameter> target = new HashMap<String, Parameter>(source.size());
+        Map<String, Parameter> target = new HashMap<>(source.size());
 
         for (Map.Entry<String, me.sokolenko.test.compareConverters.model.source.Parameter> sourceEntry : source.entrySet()) {
             target.put(sourceEntry.getKey(), toTarget(sourceEntry.getValue()));
@@ -205,13 +375,23 @@ public class ManualConverter implements Converter {
         return target;
     }
 
+    private Map<String, me.sokolenko.test.compareConverters.model.source.Parameter> toSource(Map<String, Parameter> target) {
+        Map<String, me.sokolenko.test.compareConverters.model.source.Parameter> source = new HashMap<>(target.size());
+
+        for (Map.Entry<String, Parameter> targetEntry : target.entrySet()) {
+            source.put(targetEntry.getKey(), toSource(targetEntry.getValue()));
+        }
+
+        return source;
+    }
+
     private Parameter toTarget(me.sokolenko.test.compareConverters.model.source.Parameter source) {
         Parameter target = new Parameter();
         target.setName(source.getName());
         target.setHidden(source.isHidden());
         target.setOrder(source.getOrder());
 
-        List<String> targetValues = new ArrayList<String>();
+        List<String> targetValues = new ArrayList<>();
         for (String sourceValue : source.getValues()) {
             targetValues.add(sourceValue);
         }
@@ -221,12 +401,36 @@ public class ManualConverter implements Converter {
         return target;
     }
 
+    private me.sokolenko.test.compareConverters.model.source.Parameter toSource(Parameter target) {
+        me.sokolenko.test.compareConverters.model.source.Parameter source = new me.sokolenko.test.compareConverters.model.source.Parameter();
+        source.setName(target.getName());
+        source.setHidden(target.isHidden());
+        source.setOrder(target.getOrder());
+
+        List<String> sourceValues = new ArrayList<>();
+        for (String targetValue : target.getValues()) {
+            sourceValues.add(targetValue);
+        }
+
+        source.setValues(sourceValues);
+
+        return source;
+    }
+
     private Availability toTarget(me.sokolenko.test.compareConverters.model.source.Availability source) {
         Availability target = new Availability();
         target.setSource(source.getSource());
         target.setAvailable(source.isAvailable());
 
         return target;
+    }
+
+    private me.sokolenko.test.compareConverters.model.source.Availability toSource(Availability target) {
+        me.sokolenko.test.compareConverters.model.source.Availability source = new me.sokolenko.test.compareConverters.model.source.Availability();
+        source.setSource(target.getSource());
+        source.setAvailable(target.isAvailable());
+
+        return source;
     }
 
     private Price toTarget(me.sokolenko.test.compareConverters.model.source.Price source) {
@@ -241,5 +445,19 @@ public class ManualConverter implements Converter {
         target.setOnSale(source.isOnSale());
 
         return target;
+    }
+
+    private me.sokolenko.test.compareConverters.model.source.Price toSource(Price target) {
+        me.sokolenko.test.compareConverters.model.source.Price source = new me.sokolenko.test.compareConverters.model.source.Price();
+        source.setOriginalPrice(target.getOriginalPrice());
+        source.setPreviousPrice(target.getPreviousPrice());
+        source.setRetailPrice(target.getRetailPrice());
+        source.setSalePrice(target.getSalePrice());
+        source.setFrom(new java.sql.Date(target.getFrom().getTime()));
+        source.setTo(new java.sql.Date(target.getTo().getTime()));
+        source.setDescription(target.getDescription());
+        source.setOnSale(target.isOnSale());
+
+        return source;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/source/Availability.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/source/Availability.java
@@ -1,5 +1,7 @@
 package me.sokolenko.test.compareConverters.model.source;
 
+import java.util.Objects;
+
 /**
  * @author Anatoliy Sokolenko
  */
@@ -23,5 +25,31 @@ public class Availability {
 
     public void setSource(String source) {
         this.source = source;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 97 * hash + Objects.hashCode(this.available);
+        hash = 97 * hash + Objects.hashCode(this.source);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Availability other = (Availability) obj;
+        if (!Objects.equals(this.available, other.available)) {
+            return false;
+        }
+        if (!Objects.equals(this.source, other.source)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/source/Brand.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/source/Brand.java
@@ -1,5 +1,7 @@
 package me.sokolenko.test.compareConverters.model.source;
 
+import java.util.Objects;
+
 /**
  * @author Anatoliy Sokolenko
  */
@@ -23,5 +25,31 @@ public class Brand {
 
     public void setRightOwner(String rightOwner) {
         this.rightOwner = rightOwner;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 79 * hash + Objects.hashCode(this.brandName);
+        hash = 79 * hash + Objects.hashCode(this.rightOwner);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Brand other = (Brand) obj;
+        if (!Objects.equals(this.brandName, other.brandName)) {
+            return false;
+        }
+        if (!Objects.equals(this.rightOwner, other.rightOwner)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/source/Category.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/source/Category.java
@@ -3,6 +3,7 @@ package me.sokolenko.test.compareConverters.model.source;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Anatoliy Sokolenko
@@ -310,5 +311,143 @@ public class Category {
 
     public void setResources(List<Resource> resources) {
         this.resources = resources;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 97 * hash + this.id;
+        hash = 97 * hash + Objects.hashCode(this.name);
+        hash = 97 * hash + Objects.hashCode(this.products);
+        hash = 97 * hash + Objects.hashCode(this.shipping);
+        hash = 97 * hash + Objects.hashCode(this.url);
+        hash = 97 * hash + (this.visible ? 1 : 0);
+        hash = 97 * hash + Objects.hashCode(this.type);
+        hash = 97 * hash + (this.hasChildren ? 1 : 0);
+        hash = 97 * hash + Objects.hashCode(this.relatedIds);
+        hash = 97 * hash + Objects.hashCode(this.from);
+        hash = 97 * hash + Objects.hashCode(this.clearanceStartDays);
+        hash = 97 * hash + this.position;
+        hash = 97 * hash + Objects.hashCode(this.countryEligible);
+        hash = 97 * hash + (this.isNew ? 1 : 0);
+        hash = 97 * hash + Objects.hashCode(this.active);
+        hash = 97 * hash + Objects.hashCode(this.parameters);
+        hash = 97 * hash + Objects.hashCode(this.primaryImageSource);
+        hash = 97 * hash + Objects.hashCode(this.primaryPortraitSource);
+        hash = 97 * hash + Objects.hashCode(this.availableTo);
+        hash = 97 * hash + Objects.hashCode(this.author);
+        hash = 97 * hash + Objects.hashCode(this.createdAt);
+        hash = 97 * hash + Objects.hashCode(this.updatedAt);
+        hash = 97 * hash + Objects.hashCode(this.parentCategory);
+        hash = 97 * hash + Objects.hashCode(this.domainValues);
+        hash = 97 * hash + Objects.hashCode(this.primaryImage);
+        hash = 97 * hash + Objects.hashCode(this.secondaryImages);
+        hash = 97 * hash + Objects.hashCode(this.brand);
+        hash = 97 * hash + Objects.hashCode(this.popularity);
+        hash = 97 * hash + Objects.hashCode(this.copies);
+        hash = 97 * hash + Objects.hashCode(this.resources);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Category other = (Category) obj;
+        if (this.id != other.id) {
+            return false;
+        }
+        if (!Objects.equals(this.name, other.name)) {
+            return false;
+        }
+        if (!Objects.equals(this.products, other.products)) {
+            return false;
+        }
+        if (!Objects.equals(this.shipping, other.shipping)) {
+            return false;
+        }
+        if (!Objects.equals(this.url, other.url)) {
+            return false;
+        }
+        if (this.visible != other.visible) {
+            return false;
+        }
+        if (!Objects.equals(this.type, other.type)) {
+            return false;
+        }
+        if (this.hasChildren != other.hasChildren) {
+            return false;
+        }
+        if (!Objects.equals(this.relatedIds, other.relatedIds)) {
+            return false;
+        }
+        if (!Objects.equals(this.from, other.from)) {
+            return false;
+        }
+        if (!Objects.equals(this.clearanceStartDays, other.clearanceStartDays)) {
+            return false;
+        }
+        if (this.position != other.position) {
+            return false;
+        }
+        if (!Objects.equals(this.countryEligible, other.countryEligible)) {
+            return false;
+        }
+        if (this.isNew != other.isNew) {
+            return false;
+        }
+        if (!Objects.equals(this.active, other.active)) {
+            return false;
+        }
+        if (!Objects.equals(this.parameters, other.parameters)) {
+            return false;
+        }
+        if (!Objects.equals(this.primaryImageSource, other.primaryImageSource)) {
+            return false;
+        }
+        if (!Objects.equals(this.primaryPortraitSource, other.primaryPortraitSource)) {
+            return false;
+        }
+        if (!Objects.equals(this.availableTo, other.availableTo)) {
+            return false;
+        }
+        if (!Objects.equals(this.author, other.author)) {
+            return false;
+        }
+        if (!Objects.equals(this.createdAt, other.createdAt)) {
+            return false;
+        }
+        if (!Objects.equals(this.updatedAt, other.updatedAt)) {
+            return false;
+        }
+        if (!Objects.equals(this.parentCategory, other.parentCategory)) {
+            return false;
+        }
+        if (!Objects.equals(this.domainValues, other.domainValues)) {
+            return false;
+        }
+        if (!Objects.equals(this.primaryImage, other.primaryImage)) {
+            return false;
+        }
+        if (!Objects.equals(this.secondaryImages, other.secondaryImages)) {
+            return false;
+        }
+        if (!Objects.equals(this.brand, other.brand)) {
+            return false;
+        }
+        if (!Objects.equals(this.popularity, other.popularity)) {
+            return false;
+        }
+        if (!Objects.equals(this.copies, other.copies)) {
+            return false;
+        }
+        if (!Objects.equals(this.resources, other.resources)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/source/Image.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/source/Image.java
@@ -1,5 +1,7 @@
 package me.sokolenko.test.compareConverters.model.source;
 
+import java.util.Objects;
+
 /**
  * @author Anatoliy Sokolenko
  */
@@ -23,5 +25,31 @@ public class Image {
 
     public void setSeq(Integer seq) {
         this.seq = seq;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 67 * hash + Objects.hashCode(this.name);
+        hash = 67 * hash + Objects.hashCode(this.seq);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Image other = (Image) obj;
+        if (!Objects.equals(this.name, other.name)) {
+            return false;
+        }
+        if (!Objects.equals(this.seq, other.seq)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/source/Link.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/source/Link.java
@@ -2,6 +2,7 @@ package me.sokolenko.test.compareConverters.model.source;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Anatoliy Sokolenko
@@ -56,5 +57,43 @@ public class Link {
 
     public void setParameters(List<Parameter> parameters) {
         this.parameters = parameters;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 97 * hash + Objects.hashCode(this.position);
+        hash = 97 * hash + Objects.hashCode(this.text);
+        hash = 97 * hash + Objects.hashCode(this.linkType);
+        hash = 97 * hash + Objects.hashCode(this.value);
+        hash = 97 * hash + Objects.hashCode(this.parameters);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Link other = (Link) obj;
+        if (!Objects.equals(this.position, other.position)) {
+            return false;
+        }
+        if (!Objects.equals(this.text, other.text)) {
+            return false;
+        }
+        if (this.linkType != other.linkType) {
+            return false;
+        }
+        if (!Objects.equals(this.value, other.value)) {
+            return false;
+        }
+        if (!Objects.equals(this.parameters, other.parameters)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/source/Parameter.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/source/Parameter.java
@@ -1,6 +1,7 @@
 package me.sokolenko.test.compareConverters.model.source;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Anatoliy Sokolenko
@@ -45,5 +46,39 @@ public class Parameter {
 
     public void setHidden(boolean hidden) {
         this.hidden = hidden;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 97 * hash + Objects.hashCode(this.name);
+        hash = 97 * hash + Objects.hashCode(this.values);
+        hash = 97 * hash + this.order;
+        hash = 97 * hash + (this.hidden ? 1 : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Parameter other = (Parameter) obj;
+        if (!Objects.equals(this.name, other.name)) {
+            return false;
+        }
+        if (!Objects.equals(this.values, other.values)) {
+            return false;
+        }
+        if (this.order != other.order) {
+            return false;
+        }
+        if (this.hidden != other.hidden) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/source/ParentCategory.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/source/ParentCategory.java
@@ -1,5 +1,7 @@
 package me.sokolenko.test.compareConverters.model.source;
 
+import java.util.Objects;
+
 /**
  * @author Anatoliy Sokolenko
  */
@@ -28,4 +30,29 @@ public class ParentCategory {
         this.name = name;
     }
 
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 31 * hash + this.id;
+        hash = 31 * hash + Objects.hashCode(this.name);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ParentCategory other = (ParentCategory) obj;
+        if (this.id != other.id) {
+            return false;
+        }
+        if (!Objects.equals(this.name, other.name)) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/source/Price.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/source/Price.java
@@ -1,6 +1,7 @@
 package me.sokolenko.test.compareConverters.model.source;
 
 import java.sql.Date;
+import java.util.Objects;
 
 /**
  * @author Anatoliy Sokolenko
@@ -88,5 +89,55 @@ public class Price {
 
     public void setOnSale(boolean onSale) {
         this.onSale = onSale;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 67 * hash + (int) (Double.doubleToLongBits(this.originalPrice) ^ (Double.doubleToLongBits(this.originalPrice) >>> 32));
+        hash = 67 * hash + (int) (Double.doubleToLongBits(this.previousPrice) ^ (Double.doubleToLongBits(this.previousPrice) >>> 32));
+        hash = 67 * hash + (int) (Double.doubleToLongBits(this.retailPrice) ^ (Double.doubleToLongBits(this.retailPrice) >>> 32));
+        hash = 67 * hash + (int) (Double.doubleToLongBits(this.salePrice) ^ (Double.doubleToLongBits(this.salePrice) >>> 32));
+        hash = 67 * hash + Objects.hashCode(this.from);
+        hash = 67 * hash + Objects.hashCode(this.to);
+        hash = 67 * hash + Objects.hashCode(this.description);
+        hash = 67 * hash + (this.onSale ? 1 : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Price other = (Price) obj;
+        if (Double.doubleToLongBits(this.originalPrice) != Double.doubleToLongBits(other.originalPrice)) {
+            return false;
+        }
+        if (Double.doubleToLongBits(this.previousPrice) != Double.doubleToLongBits(other.previousPrice)) {
+            return false;
+        }
+        if (Double.doubleToLongBits(this.retailPrice) != Double.doubleToLongBits(other.retailPrice)) {
+            return false;
+        }
+        if (Double.doubleToLongBits(this.salePrice) != Double.doubleToLongBits(other.salePrice)) {
+            return false;
+        }
+        if (!Objects.equals(this.from, other.from)) {
+            return false;
+        }
+        if (!Objects.equals(this.to, other.to)) {
+            return false;
+        }
+        if (!Objects.equals(this.description, other.description)) {
+            return false;
+        }
+        if (this.onSale != other.onSale) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/source/Product.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/source/Product.java
@@ -1,6 +1,7 @@
 package me.sokolenko.test.compareConverters.model.source;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Anatoliy Sokolenko
@@ -155,5 +156,83 @@ public class Product {
 
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 71 * hash + Objects.hashCode(this.id);
+        hash = 71 * hash + Objects.hashCode(this.price);
+        hash = 71 * hash + Objects.hashCode(this.availability);
+        hash = 71 * hash + Objects.hashCode(this.indicator);
+        hash = 71 * hash + (this.enabled ? 1 : 0);
+        hash = 71 * hash + Objects.hashCode(this.addByApp);
+        hash = 71 * hash + Objects.hashCode(this.description);
+        hash = 71 * hash + Objects.hashCode(this.code);
+        hash = 71 * hash + Objects.hashCode(this.expired);
+        hash = 71 * hash + (int) (Double.doubleToLongBits(this.surchargeFee) ^ (Double.doubleToLongBits(this.surchargeFee) >>> 32));
+        hash = 71 * hash + (this.history ? 1 : 0);
+        hash = 71 * hash + (this.orderable ? 1 : 0);
+        hash = 71 * hash + (this.backorderable ? 1 : 0);
+        hash = 71 * hash + Objects.hashCode(this.attributes);
+        hash = 71 * hash + Objects.hashCode(this.active);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Product other = (Product) obj;
+        if (!Objects.equals(this.id, other.id)) {
+            return false;
+        }
+        if (!Objects.equals(this.price, other.price)) {
+            return false;
+        }
+        if (!Objects.equals(this.availability, other.availability)) {
+            return false;
+        }
+        if (!Objects.equals(this.indicator, other.indicator)) {
+            return false;
+        }
+        if (this.enabled != other.enabled) {
+            return false;
+        }
+        if (!Objects.equals(this.addByApp, other.addByApp)) {
+            return false;
+        }
+        if (!Objects.equals(this.description, other.description)) {
+            return false;
+        }
+        if (!Objects.equals(this.code, other.code)) {
+            return false;
+        }
+        if (!Objects.equals(this.expired, other.expired)) {
+            return false;
+        }
+        if (Double.doubleToLongBits(this.surchargeFee) != Double.doubleToLongBits(other.surchargeFee)) {
+            return false;
+        }
+        if (this.history != other.history) {
+            return false;
+        }
+        if (this.orderable != other.orderable) {
+            return false;
+        }
+        if (this.backorderable != other.backorderable) {
+            return false;
+        }
+        if (!Objects.equals(this.attributes, other.attributes)) {
+            return false;
+        }
+        if (!Objects.equals(this.active, other.active)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/source/Resource.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/source/Resource.java
@@ -2,6 +2,7 @@ package me.sokolenko.test.compareConverters.model.source;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Anatoliy Sokolenko
@@ -96,5 +97,59 @@ public class Resource {
 
     public void setParameters(List<Parameter> parameters) {
         this.parameters = parameters;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 97 * hash + Objects.hashCode(this.id);
+        hash = 97 * hash + Objects.hashCode(this.links);
+        hash = 97 * hash + Objects.hashCode(this.fileName);
+        hash = 97 * hash + this.height;
+        hash = 97 * hash + this.width;
+        hash = 97 * hash + Objects.hashCode(this.text);
+        hash = 97 * hash + Objects.hashCode(this.description);
+        hash = 97 * hash + Objects.hashCode(this.type);
+        hash = 97 * hash + Objects.hashCode(this.parameters);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Resource other = (Resource) obj;
+        if (!Objects.equals(this.id, other.id)) {
+            return false;
+        }
+        if (!Objects.equals(this.links, other.links)) {
+            return false;
+        }
+        if (!Objects.equals(this.fileName, other.fileName)) {
+            return false;
+        }
+        if (this.height != other.height) {
+            return false;
+        }
+        if (this.width != other.width) {
+            return false;
+        }
+        if (!Objects.equals(this.text, other.text)) {
+            return false;
+        }
+        if (!Objects.equals(this.description, other.description)) {
+            return false;
+        }
+        if (this.type != other.type) {
+            return false;
+        }
+        if (!Objects.equals(this.parameters, other.parameters)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/source/ShippingRule.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/source/ShippingRule.java
@@ -1,6 +1,7 @@
 package me.sokolenko.test.compareConverters.model.source;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -46,5 +47,39 @@ public class ShippingRule {
 
     public void setShipDays(int shipDays) {
         this.shipDays = shipDays;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 23 * hash + Objects.hashCode(this.returnConstraints);
+        hash = 23 * hash + Objects.hashCode(this.notes);
+        hash = 23 * hash + Objects.hashCode(this.giftable);
+        hash = 23 * hash + this.shipDays;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ShippingRule other = (ShippingRule) obj;
+        if (!Objects.equals(this.returnConstraints, other.returnConstraints)) {
+            return false;
+        }
+        if (!Objects.equals(this.notes, other.notes)) {
+            return false;
+        }
+        if (!Objects.equals(this.giftable, other.giftable)) {
+            return false;
+        }
+        if (this.shipDays != other.shipDays) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/target/Availability.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/target/Availability.java
@@ -1,5 +1,7 @@
 package me.sokolenko.test.compareConverters.model.target;
 
+import java.util.Objects;
+
 /**
  * @author Anatoliy Sokolenko
  */
@@ -23,5 +25,31 @@ public class Availability {
 
     public void setSource(String source) {
         this.source = source;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 97 * hash + Objects.hashCode(this.available);
+        hash = 97 * hash + Objects.hashCode(this.source);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Availability other = (Availability) obj;
+        if (!Objects.equals(this.available, other.available)) {
+            return false;
+        }
+        if (!Objects.equals(this.source, other.source)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/target/Brand.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/target/Brand.java
@@ -1,5 +1,7 @@
 package me.sokolenko.test.compareConverters.model.target;
 
+import java.util.Objects;
+
 /**
  * @author Anatoliy Sokolenko
  */
@@ -23,5 +25,31 @@ public class Brand {
 
     public void setRightOwner(String rightOwner) {
         this.rightOwner = rightOwner;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 79 * hash + Objects.hashCode(this.brandName);
+        hash = 79 * hash + Objects.hashCode(this.rightOwner);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Brand other = (Brand) obj;
+        if (!Objects.equals(this.brandName, other.brandName)) {
+            return false;
+        }
+        if (!Objects.equals(this.rightOwner, other.rightOwner)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/target/Category.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/target/Category.java
@@ -3,6 +3,7 @@ package me.sokolenko.test.compareConverters.model.target;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Anatoliy Sokolenko
@@ -310,5 +311,143 @@ public class Category {
 
     public void setResources(List<Resource> resources) {
         this.resources = resources;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 97 * hash + this.id;
+        hash = 97 * hash + Objects.hashCode(this.categoryName);
+        hash = 97 * hash + Objects.hashCode(this.products);
+        hash = 97 * hash + Objects.hashCode(this.shipping);
+        hash = 97 * hash + Objects.hashCode(this.url);
+        hash = 97 * hash + (this.visible ? 1 : 0);
+        hash = 97 * hash + Objects.hashCode(this.type);
+        hash = 97 * hash + (this.hasChildren ? 1 : 0);
+        hash = 97 * hash + Objects.hashCode(this.relatedIds);
+        hash = 97 * hash + Objects.hashCode(this.from);
+        hash = 97 * hash + Objects.hashCode(this.clearanceStartDays);
+        hash = 97 * hash + this.position;
+        hash = 97 * hash + Objects.hashCode(this.countryEligible);
+        hash = 97 * hash + (this.isNew ? 1 : 0);
+        hash = 97 * hash + Objects.hashCode(this.active);
+        hash = 97 * hash + Objects.hashCode(this.parameters);
+        hash = 97 * hash + Objects.hashCode(this.primaryImageSource);
+        hash = 97 * hash + Objects.hashCode(this.primaryPortraitSource);
+        hash = 97 * hash + Objects.hashCode(this.availableTo);
+        hash = 97 * hash + Objects.hashCode(this.author);
+        hash = 97 * hash + Objects.hashCode(this.createdAt);
+        hash = 97 * hash + Objects.hashCode(this.updatedAt);
+        hash = 97 * hash + Objects.hashCode(this.parentCategory);
+        hash = 97 * hash + Objects.hashCode(this.domainValues);
+        hash = 97 * hash + Objects.hashCode(this.primaryImage);
+        hash = 97 * hash + Objects.hashCode(this.secondaryImages);
+        hash = 97 * hash + Objects.hashCode(this.brand);
+        hash = 97 * hash + Objects.hashCode(this.popularity);
+        hash = 97 * hash + Objects.hashCode(this.copies);
+        hash = 97 * hash + Objects.hashCode(this.resources);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Category other = (Category) obj;
+        if (this.id != other.id) {
+            return false;
+        }
+        if (!Objects.equals(this.categoryName, other.categoryName)) {
+            return false;
+        }
+        if (!Objects.equals(this.products, other.products)) {
+            return false;
+        }
+        if (!Objects.equals(this.shipping, other.shipping)) {
+            return false;
+        }
+        if (!Objects.equals(this.url, other.url)) {
+            return false;
+        }
+        if (this.visible != other.visible) {
+            return false;
+        }
+        if (!Objects.equals(this.type, other.type)) {
+            return false;
+        }
+        if (this.hasChildren != other.hasChildren) {
+            return false;
+        }
+        if (!Objects.equals(this.relatedIds, other.relatedIds)) {
+            return false;
+        }
+        if (!Objects.equals(this.from, other.from)) {
+            return false;
+        }
+        if (!Objects.equals(this.clearanceStartDays, other.clearanceStartDays)) {
+            return false;
+        }
+        if (this.position != other.position) {
+            return false;
+        }
+        if (!Objects.equals(this.countryEligible, other.countryEligible)) {
+            return false;
+        }
+        if (this.isNew != other.isNew) {
+            return false;
+        }
+        if (!Objects.equals(this.active, other.active)) {
+            return false;
+        }
+        if (!Objects.equals(this.parameters, other.parameters)) {
+            return false;
+        }
+        if (!Objects.equals(this.primaryImageSource, other.primaryImageSource)) {
+            return false;
+        }
+        if (!Objects.equals(this.primaryPortraitSource, other.primaryPortraitSource)) {
+            return false;
+        }
+        if (!Objects.equals(this.availableTo, other.availableTo)) {
+            return false;
+        }
+        if (!Objects.equals(this.author, other.author)) {
+            return false;
+        }
+        if (!Objects.equals(this.createdAt, other.createdAt)) {
+            return false;
+        }
+        if (!Objects.equals(this.updatedAt, other.updatedAt)) {
+            return false;
+        }
+        if (!Objects.equals(this.parentCategory, other.parentCategory)) {
+            return false;
+        }
+        if (!Objects.equals(this.domainValues, other.domainValues)) {
+            return false;
+        }
+        if (!Objects.equals(this.primaryImage, other.primaryImage)) {
+            return false;
+        }
+        if (!Objects.equals(this.secondaryImages, other.secondaryImages)) {
+            return false;
+        }
+        if (!Objects.equals(this.brand, other.brand)) {
+            return false;
+        }
+        if (!Objects.equals(this.popularity, other.popularity)) {
+            return false;
+        }
+        if (!Objects.equals(this.copies, other.copies)) {
+            return false;
+        }
+        if (!Objects.equals(this.resources, other.resources)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/target/Image.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/target/Image.java
@@ -1,5 +1,7 @@
 package me.sokolenko.test.compareConverters.model.target;
 
+import java.util.Objects;
+
 /**
  * @author Anatoliy Sokolenko
  */
@@ -23,5 +25,31 @@ public class Image {
 
     public void setSeq(Integer seq) {
         this.seq = seq;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 67 * hash + Objects.hashCode(this.name);
+        hash = 67 * hash + Objects.hashCode(this.seq);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Image other = (Image) obj;
+        if (!Objects.equals(this.name, other.name)) {
+            return false;
+        }
+        if (!Objects.equals(this.seq, other.seq)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/target/Link.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/target/Link.java
@@ -2,6 +2,7 @@ package me.sokolenko.test.compareConverters.model.target;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Anatoliy Sokolenko
@@ -56,5 +57,43 @@ public class Link {
 
     public void setParameters(List<Parameter> parameters) {
         this.parameters = parameters;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 97 * hash + Objects.hashCode(this.position);
+        hash = 97 * hash + Objects.hashCode(this.text);
+        hash = 97 * hash + Objects.hashCode(this.linkType);
+        hash = 97 * hash + Objects.hashCode(this.value);
+        hash = 97 * hash + Objects.hashCode(this.parameters);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Link other = (Link) obj;
+        if (!Objects.equals(this.position, other.position)) {
+            return false;
+        }
+        if (!Objects.equals(this.text, other.text)) {
+            return false;
+        }
+        if (this.linkType != other.linkType) {
+            return false;
+        }
+        if (!Objects.equals(this.value, other.value)) {
+            return false;
+        }
+        if (!Objects.equals(this.parameters, other.parameters)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/target/Parameter.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/target/Parameter.java
@@ -1,6 +1,7 @@
 package me.sokolenko.test.compareConverters.model.target;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Anatoliy Sokolenko
@@ -45,5 +46,39 @@ public class Parameter {
 
     public void setHidden(boolean hidden) {
         this.hidden = hidden;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 97 * hash + Objects.hashCode(this.name);
+        hash = 97 * hash + Objects.hashCode(this.values);
+        hash = 97 * hash + this.order;
+        hash = 97 * hash + (this.hidden ? 1 : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Parameter other = (Parameter) obj;
+        if (!Objects.equals(this.name, other.name)) {
+            return false;
+        }
+        if (!Objects.equals(this.values, other.values)) {
+            return false;
+        }
+        if (this.order != other.order) {
+            return false;
+        }
+        if (this.hidden != other.hidden) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/target/ParentCategory.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/target/ParentCategory.java
@@ -1,5 +1,7 @@
 package me.sokolenko.test.compareConverters.model.target;
 
+import java.util.Objects;
+
 /**
  * @author Anatoliy Sokolenko
  */
@@ -28,4 +30,29 @@ public class ParentCategory {
         this.name = name;
     }
 
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 31 * hash + this.id;
+        hash = 31 * hash + Objects.hashCode(this.name);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ParentCategory other = (ParentCategory) obj;
+        if (this.id != other.id) {
+            return false;
+        }
+        if (!Objects.equals(this.name, other.name)) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/target/Price.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/target/Price.java
@@ -1,6 +1,7 @@
 package me.sokolenko.test.compareConverters.model.target;
 
 import java.util.Date;
+import java.util.Objects;
 
 /**
  * @author Anatoliy Sokolenko
@@ -88,5 +89,55 @@ public class Price {
 
     public void setOnSale(Boolean onSale) {
         this.onSale = onSale;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 67 * hash + (int) (Double.doubleToLongBits(this.originalPrice) ^ (Double.doubleToLongBits(this.originalPrice) >>> 32));
+        hash = 67 * hash + (int) (Double.doubleToLongBits(this.previousPrice) ^ (Double.doubleToLongBits(this.previousPrice) >>> 32));
+        hash = 67 * hash + (int) (Double.doubleToLongBits(this.retailPrice) ^ (Double.doubleToLongBits(this.retailPrice) >>> 32));
+        hash = 67 * hash + (int) (Double.doubleToLongBits(this.salePrice) ^ (Double.doubleToLongBits(this.salePrice) >>> 32));
+        hash = 67 * hash + Objects.hashCode(this.from);
+        hash = 67 * hash + Objects.hashCode(this.to);
+        hash = 67 * hash + Objects.hashCode(this.description);
+        hash = 67 * hash + (this.onSale ? 1 : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Price other = (Price) obj;
+        if (Double.doubleToLongBits(this.originalPrice) != Double.doubleToLongBits(other.originalPrice)) {
+            return false;
+        }
+        if (Double.doubleToLongBits(this.previousPrice) != Double.doubleToLongBits(other.previousPrice)) {
+            return false;
+        }
+        if (Double.doubleToLongBits(this.retailPrice) != Double.doubleToLongBits(other.retailPrice)) {
+            return false;
+        }
+        if (Double.doubleToLongBits(this.salePrice) != Double.doubleToLongBits(other.salePrice)) {
+            return false;
+        }
+        if (!Objects.equals(this.from, other.from)) {
+            return false;
+        }
+        if (!Objects.equals(this.to, other.to)) {
+            return false;
+        }
+        if (!Objects.equals(this.description, other.description)) {
+            return false;
+        }
+        if (this.onSale != other.onSale) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/target/Product.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/target/Product.java
@@ -1,6 +1,7 @@
 package me.sokolenko.test.compareConverters.model.target;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Anatoliy Sokolenko
@@ -155,5 +156,83 @@ public class Product {
 
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 71 * hash + Objects.hashCode(this.id);
+        hash = 71 * hash + Objects.hashCode(this.price);
+        hash = 71 * hash + Objects.hashCode(this.availability);
+        hash = 71 * hash + Objects.hashCode(this.indicator);
+        hash = 71 * hash + (this.enabled ? 1 : 0);
+        hash = 71 * hash + Objects.hashCode(this.addByApp);
+        hash = 71 * hash + Objects.hashCode(this.description);
+        hash = 71 * hash + Objects.hashCode(this.code);
+        hash = 71 * hash + Objects.hashCode(this.expired);
+        hash = 71 * hash + (int) (Double.doubleToLongBits(this.surchargeFee) ^ (Double.doubleToLongBits(this.surchargeFee) >>> 32));
+        hash = 71 * hash + (this.history ? 1 : 0);
+        hash = 71 * hash + (this.orderable ? 1 : 0);
+        hash = 71 * hash + (this.backorderable ? 1 : 0);
+        hash = 71 * hash + Objects.hashCode(this.parameters);
+        hash = 71 * hash + Objects.hashCode(this.active);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Product other = (Product) obj;
+        if (!Objects.equals(this.id, other.id)) {
+            return false;
+        }
+        if (!Objects.equals(this.price, other.price)) {
+            return false;
+        }
+        if (!Objects.equals(this.availability, other.availability)) {
+            return false;
+        }
+        if (!Objects.equals(this.indicator, other.indicator)) {
+            return false;
+        }
+        if (this.enabled != other.enabled) {
+            return false;
+        }
+        if (!Objects.equals(this.addByApp, other.addByApp)) {
+            return false;
+        }
+        if (!Objects.equals(this.description, other.description)) {
+            return false;
+        }
+        if (!Objects.equals(this.code, other.code)) {
+            return false;
+        }
+        if (!Objects.equals(this.expired, other.expired)) {
+            return false;
+        }
+        if (Double.doubleToLongBits(this.surchargeFee) != Double.doubleToLongBits(other.surchargeFee)) {
+            return false;
+        }
+        if (this.history != other.history) {
+            return false;
+        }
+        if (this.orderable != other.orderable) {
+            return false;
+        }
+        if (this.backorderable != other.backorderable) {
+            return false;
+        }
+        if (!Objects.equals(this.parameters, other.parameters)) {
+            return false;
+        }
+        if (!Objects.equals(this.active, other.active)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/target/Resource.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/target/Resource.java
@@ -2,6 +2,7 @@ package me.sokolenko.test.compareConverters.model.target;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Anatoliy Sokolenko
@@ -96,5 +97,59 @@ public class Resource {
 
     public void setParameters(List<Parameter> parameters) {
         this.parameters = parameters;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 97 * hash + Objects.hashCode(this.id);
+        hash = 97 * hash + Objects.hashCode(this.links);
+        hash = 97 * hash + Objects.hashCode(this.fileName);
+        hash = 97 * hash + (int) (Double.doubleToLongBits(this.height) ^ (Double.doubleToLongBits(this.height) >>> 32));
+        hash = 97 * hash + (int) (Double.doubleToLongBits(this.width) ^ (Double.doubleToLongBits(this.width) >>> 32));
+        hash = 97 * hash + Objects.hashCode(this.text);
+        hash = 97 * hash + Objects.hashCode(this.description);
+        hash = 97 * hash + Objects.hashCode(this.type);
+        hash = 97 * hash + Objects.hashCode(this.parameters);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Resource other = (Resource) obj;
+        if (!Objects.equals(this.id, other.id)) {
+            return false;
+        }
+        if (!Objects.equals(this.links, other.links)) {
+            return false;
+        }
+        if (!Objects.equals(this.fileName, other.fileName)) {
+            return false;
+        }
+        if (Double.doubleToLongBits(this.height) != Double.doubleToLongBits(other.height)) {
+            return false;
+        }
+        if (Double.doubleToLongBits(this.width) != Double.doubleToLongBits(other.width)) {
+            return false;
+        }
+        if (!Objects.equals(this.text, other.text)) {
+            return false;
+        }
+        if (!Objects.equals(this.description, other.description)) {
+            return false;
+        }
+        if (this.type != other.type) {
+            return false;
+        }
+        if (!Objects.equals(this.parameters, other.parameters)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/model/target/ShippingRule.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/model/target/ShippingRule.java
@@ -1,6 +1,7 @@
 package me.sokolenko.test.compareConverters.model.target;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -46,5 +47,39 @@ public class ShippingRule {
 
     public void setShipDays(int shipDays) {
         this.shipDays = shipDays;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 23 * hash + Objects.hashCode(this.returnConstraints);
+        hash = 23 * hash + Objects.hashCode(this.notes);
+        hash = 23 * hash + Objects.hashCode(this.giftable);
+        hash = 23 * hash + this.shipDays;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ShippingRule other = (ShippingRule) obj;
+        if (!Objects.equals(this.returnConstraints, other.returnConstraints)) {
+            return false;
+        }
+        if (!Objects.equals(this.notes, other.notes)) {
+            return false;
+        }
+        if (!Objects.equals(this.giftable, other.giftable)) {
+            return false;
+        }
+        if (this.shipDays != other.shipDays) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/me/sokolenko/test/compareConverters/orika/OrikaConverter.java
+++ b/src/main/java/me/sokolenko/test/compareConverters/orika/OrikaConverter.java
@@ -1,17 +1,18 @@
 package me.sokolenko.test.compareConverters.orika;
 
-import ma.glasnost.orika.MapperFacade;
+import ma.glasnost.orika.BoundMapperFacade;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
 import me.sokolenko.test.compareConverters.Converter;
 import me.sokolenko.test.compareConverters.model.source.Category;
+import me.sokolenko.test.compareConverters.model.source.Product;
 
 /**
  * @author Anatoliy Sokolenko
  */
 public class OrikaConverter implements Converter {
 
-    private final MapperFacade mapper;
+    private final BoundMapperFacade<Category, me.sokolenko.test.compareConverters.model.target.Category> mapper;
 
     public OrikaConverter() {
         MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
@@ -21,11 +22,21 @@ public class OrikaConverter implements Converter {
                 .field("name", "categoryName")
                 .byDefault().register();
 
-        mapper = mapperFactory.getMapperFacade();
+        mapperFactory.classMap(Product.class,
+                me.sokolenko.test.compareConverters.model.target.Product.class)
+                .field("attributes", "parameters")
+                .byDefault().register();
+
+        mapper = mapperFactory.getMapperFacade(Category.class, me.sokolenko.test.compareConverters.model.target.Category.class);
     }
 
     @Override
     public me.sokolenko.test.compareConverters.model.target.Category map(Category source) {
-        return mapper.map(source, me.sokolenko.test.compareConverters.model.target.Category.class);
+        return mapper.map(source);
+    }
+
+    @Override
+    public Category unmap(me.sokolenko.test.compareConverters.model.target.Category source) {
+        return mapper.mapReverse(source);
     }
 }

--- a/src/main/resources/me/sokolenko/test/compareConverters/dozer/dozer-mapping.xml
+++ b/src/main/resources/me/sokolenko/test/compareConverters/dozer/dozer-mapping.xml
@@ -11,11 +11,38 @@
   </configuration>
 
   <mapping>
+    <class-a>me.sokolenko.test.compareConverters.model.target.Availability</class-a>
+    <class-b>me.sokolenko.test.compareConverters.model.source.Availability</class-b>
+    <field>
+      <a>available</a>
+      <b get-method="isAvailable">available</b>
+    </field>
+  </mapping>
+
+  <mapping>
     <class-a>me.sokolenko.test.compareConverters.model.target.Category</class-a>
     <class-b>me.sokolenko.test.compareConverters.model.source.Category</class-b>
     <field>
       <a>categoryName</a>
       <b>name</b>
+    </field>
+  </mapping>
+
+  <mapping>
+    <class-a>me.sokolenko.test.compareConverters.model.target.Price</class-a>
+    <class-b>me.sokolenko.test.compareConverters.model.source.Price</class-b>
+    <field>
+      <a get-method="isOnSale">onSale</a>
+      <b>onSale</b>
+    </field>
+  </mapping>
+
+  <mapping>
+    <class-a>me.sokolenko.test.compareConverters.model.target.Product</class-a>
+    <class-b>me.sokolenko.test.compareConverters.model.source.Product</class-b>
+    <field>
+      <a>parameters</a>
+      <b>attributes</b>
     </field>
   </mapping>
 </mappings>


### PR DESCRIPTION
Some properties weren't being mapped, because Dozer doesn't consider 'Boolean isFoo()'
to be an accessor (only 'boolean isFoo()')

The Dozer and Orkia tests were also missing the attribute name change on Product
(attributes vs parameters)

To fix this, check (but don't time) the reverse mapping, and confirm that the
objects are all equal. Adding equals() methods was easier using java.util.Objects
which required JDK1.7
